### PR TITLE
Text, Formatting, and Style API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ group = project.maven_group
 repositories {
     mavenCentral()
     maven { url 'https://jitpack.io' }
+    maven { url 'https://libraries.minecraft.net' }
 }
 
 configurations {
@@ -29,6 +30,7 @@ dependencies {
     shade 'com.github.zafarkhaja:java-semver:0.9.0'
     implementation group: 'com.google.guava', name: 'guava', version: '21.0'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
+    compile group: 'com.mojang', name: 'brigadier', version: '1.0.17'
 }
 
 jar {

--- a/src/main/java/org/sandboxpowered/sandbox/api/util/Functions.java
+++ b/src/main/java/org/sandboxpowered/sandbox/api/util/Functions.java
@@ -18,6 +18,7 @@ import org.sandboxpowered.sandbox.api.util.math.Position;
 import org.sandboxpowered.sandbox.api.util.math.Vec3i;
 import org.sandboxpowered.sandbox.api.util.nbt.CompoundTag;
 import org.sandboxpowered.sandbox.api.util.nbt.ReadableCompoundTag;
+import org.sandboxpowered.sandbox.api.util.text.Formatting;
 import org.sandboxpowered.sandbox.api.util.text.Text;
 
 import java.util.function.BiFunction;
@@ -88,5 +89,8 @@ public class Functions {
     };
     public static final Function<ReadableCompoundTag, ItemStack> itemStackFromTagFunction = tag -> {
         throw new RuntimeException("No ItemStack Tag Function Loaded, Report this as a bug!");
+    };
+    public static final Function<String, Formatting> formattingFunction = name -> {
+        throw new RuntimeException("No Formatting Function Loaded, Report this as a bug!");
     };
 }

--- a/src/main/java/org/sandboxpowered/sandbox/api/util/text/Formatting.java
+++ b/src/main/java/org/sandboxpowered/sandbox/api/util/text/Formatting.java
@@ -1,0 +1,53 @@
+package org.sandboxpowered.sandbox.api.util.text;
+
+import org.sandboxpowered.sandbox.api.util.Functions;
+import org.sandboxpowered.sandbox.api.util.Mono;
+
+public interface Formatting {
+    Formatting BLACK = get("BLACK");
+    Formatting DARK_BLUE = get("DARK_BLUE");
+    Formatting DARK_GREEN = get("DARK_GREEN");
+    Formatting DARK_AQUA = get("DARK_AQUA");
+    Formatting DARK_RED = get("DARK_RED");
+    Formatting DARK_PURPLE = get("DARK_PURPLE");
+    Formatting GOLD = get("GOLD");
+    Formatting GRAY = get("GRAY");
+    Formatting DARK_GRAY = get("DARK_GRAY");
+    Formatting BLUE = get("BLUE");
+    Formatting GREEN = get("GREEN");
+    Formatting AQUA = get("AQUA");
+    Formatting RED = get("RED");
+    Formatting LIGHT_PURPLE = get("LIGHT_PURPLE");
+    Formatting YELLOW = get("YELLOW");
+    Formatting WHITE = get("WHITE");
+    Formatting OBFUSCATED = get("OBFUSCATED");
+    Formatting BOLD = get("BOLD");
+    Formatting STRIKETHROUGH = get("STRIKETHROUGH");
+    Formatting UNDERLINE = get("UNDERLINE");
+    Formatting ITALIC = get("ITALIC");
+    Formatting RESET = get("RESET");
+
+    //TODO: getFormatAtEnd?
+
+    int getColorIndex();
+
+    boolean isModifier();
+
+    boolean isColor();
+
+    Mono<Integer> getColorValue();
+
+    boolean affectsGlyphWidth();
+
+    String getName();
+
+    String toString();
+
+    Mono<String> strip(Mono<String> toStrip);
+
+    //TODO: byName, byColorIndex, byCode, getNames
+
+    static Formatting get(String name) {
+        return Functions.formattingFunction.apply(name);
+    }
+}

--- a/src/main/java/org/sandboxpowered/sandbox/api/util/text/Style.java
+++ b/src/main/java/org/sandboxpowered/sandbox/api/util/text/Style.java
@@ -1,0 +1,54 @@
+package org.sandboxpowered.sandbox.api.util.text;
+
+import org.sandboxpowered.sandbox.api.util.Mono;
+
+public interface Style {
+
+    Mono<Formatting> getColor();
+
+    boolean isBold();
+
+    boolean isItalic();
+
+    boolean isStrikethrough();
+
+    boolean isUnderlined();
+
+    boolean isObfuscated();
+
+    boolean isEmpty();
+
+    //TODO: getClickEvent, getHoverEvent (as monos)
+
+    Mono<String> getInsertion();
+
+    Style setColor(Formatting formatting);
+
+    Style setBold(boolean bold);
+
+    Style setItalic(boolean italic);
+
+    Style setStrikethrough(boolean strikethrough);
+
+    Style setUnderlined(boolean underlined);
+
+    Style setObfuscated(boolean obfuscated);
+
+    //TODO: setClickEvent, setHoverEvent
+
+    Style setInsertion(String insertion);
+
+    Style setParent(Style parent);
+
+    String asString();
+
+    Style getParent();
+
+    //TODO: have impl do the toString, equals, hashCode
+
+    Style deepCopy();
+
+    Style copy();
+
+    //TODO: Serializer?
+}

--- a/src/main/java/org/sandboxpowered/sandbox/api/util/text/Text.java
+++ b/src/main/java/org/sandboxpowered/sandbox/api/util/text/Text.java
@@ -1,10 +1,15 @@
 package org.sandboxpowered.sandbox.api.util.text;
 
 import com.google.common.annotations.Beta;
+import com.mojang.brigadier.Message;
 import org.sandboxpowered.sandbox.api.util.Functions;
 
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
 @Beta
-public interface Text {
+public interface Text extends Message, Iterable<Text> {
 
     static Text literal(String text) {
         return Functions.literalTextFunction.apply(text);
@@ -13,6 +18,10 @@ public interface Text {
     static Text translatable(String text) {
         return Functions.translatedTextFunction.apply(text);
     }
+
+    Text setStyle(Style style);
+
+    Style getStyle();
 
     default void append(String string) {
         this.append(literal(string));
@@ -23,4 +32,24 @@ public interface Text {
     String asString();
 
     String asFormattedString();
+
+    String asTruncatedString(int sections);
+
+    List<Text> getSiblings();
+
+    Stream<Text> stream();
+
+    Stream<Text> streamCopied();
+
+    Text copy();
+
+    Text deepCopy();
+
+    Text styled(Consumer<Style> styleConsumer);
+
+    Text formatted(Formatting... formatting);
+
+    Text formatted(Formatting formatting);
+
+    //TODO: copyWithoutChildren and Serializer?
 }


### PR DESCRIPTION
Still needs a bit of work to both fix merge conflicts and implement the last few bits that aren't in yet.

This adds an API for text elements, so that mods can send messages to players and the like. Also important for tooltips.

Adds in Brigadier as a `compile` dependency, since we need it anyway for commands and vanilla `Text` implements Brigadier's `Message`