### PR TITLE
Status Effect & Potion API

### DIFF
--- a/base/src/main/java/org/sandboxpowered/api/status/StatusEffect.java
+++ b/base/src/main/java/org/sandboxpowered/api/status/StatusEffect.java
@@ -1,0 +1,49 @@
+package org.sandboxpowered.api.status;
+
+import org.sandboxpowered.api.content.Content;
+import org.sandboxpowered.api.entity.Entity;
+import org.sandboxpowered.api.entity.LivingEntity;
+import org.sandboxpowered.api.registry.Registry;
+import org.sandboxpowered.api.util.Mono;
+import org.sandboxpowered.api.util.text.Text;
+
+public interface StatusEffect extends Content<StatusEffect> {
+	Registry<StatusEffect> REGISTRY = Registry.getRegistryFromType(StatusEffect.class);
+
+	StatusEffectType getType();
+
+	void applyUpdateEffect(LivingEntity entity, int amplifier);
+
+	//TODO: double-check damage source to make sure the thrower and the potion are named right
+	void applyInstantEffect(Mono<Entity> thrower, Mono<Entity> potion, LivingEntity target, int amplifier, double distance);
+
+	boolean shouldApplyUpdateEffect(int ticksLeft, int amplifier);
+
+	boolean isInstant();
+
+	String getTranslationKey();
+
+	default Text getName() {
+		return Text.translatable(getTranslationKey());
+	}
+
+	int getColor();
+
+	//TODO: implement entity attributes/EAMs in Sandbox, probably with components
+//    StatusEffect addAttributeModifiers(EntityAttribute attribute, String name, double amount, EntityAttributeModifier.Operation operation);
+
+//    Map<EntityAttribute, EntityAttributeModifier> getAttributeModifiers();
+
+//    void removeAttributeModifiers(LivingEntity entity, EntityAttributeContainer attribContainer, int amplifier);
+
+//    void addAttributeModifiers(LivingEntity entity, EntityAttributeContainer attribContainer, int amplifier);
+
+//    double getAttribModifierAmount(int amplifier, EntitiyAttributeModifier eam);
+
+	boolean isBeneficial();
+
+	@Override
+	default Class<StatusEffect> getContentType() {
+		return StatusEffect.class;
+	}
+}

--- a/base/src/main/java/org/sandboxpowered/api/status/StatusEffectInstance.java
+++ b/base/src/main/java/org/sandboxpowered/api/status/StatusEffectInstance.java
@@ -1,0 +1,38 @@
+package org.sandboxpowered.api.status;
+
+import org.sandboxpowered.api.entity.LivingEntity;
+import org.sandboxpowered.api.util.Functions;
+
+public interface StatusEffectInstance extends Comparable<StatusEffectInstance> {
+	static StatusEffectInstance of(StatusEffect effect, int duration, int amplifier) {
+		return Functions.getInstance().createStatusEffectInstance(effect, duration, amplifier);
+	}
+
+	StatusEffect getEffect();
+
+	int getDuration();
+
+	//TODO: zero-index to keep in-line with vanilla code, or one-index to keep in-line with vanilla display?
+	int getAmplifier();
+
+	boolean isAmbient();
+
+	boolean showParticles();
+
+	boolean showIcon();
+
+	boolean update(LivingEntity entity);
+
+	void applyUpdateEffect(LivingEntity entity);
+
+	String getTranslationKey();
+
+	//TODO: impl vanilla's toString, equals, hashCode, compareTo overrides?
+
+	//TODO: impl vanilla's serialization?
+
+	void setPermanent(boolean permanet);
+
+	boolean isPermanent();
+
+}

--- a/base/src/main/java/org/sandboxpowered/api/status/StatusEffectType.java
+++ b/base/src/main/java/org/sandboxpowered/api/status/StatusEffectType.java
@@ -1,0 +1,15 @@
+package org.sandboxpowered.api.status;
+
+import org.sandboxpowered.api.util.Functions;
+
+public interface StatusEffectType {
+	//TODO: need text formatting implemented to properly mirror vanilla status effect type
+	StatusEffectType BENEFICIAL = getEffectType("beneficial");
+	StatusEffectType NEUTRAL = getEffectType("neutral");
+	StatusEffectType HARMFUL = getEffectType("harmful");
+
+
+	static StatusEffectType getEffectType(String type) {
+		return Functions.getInstance().createStatusEffectType(type);
+	}
+}

--- a/base/src/main/java/org/sandboxpowered/api/status/StatusEffects.java
+++ b/base/src/main/java/org/sandboxpowered/api/status/StatusEffects.java
@@ -1,0 +1,44 @@
+package org.sandboxpowered.api.status;
+
+import org.sandboxpowered.api.registry.Registry;
+import org.sandboxpowered.api.util.Functions;
+import org.sandboxpowered.api.util.Identity;
+
+public class StatusEffects {
+	public static final Registry.Entry<StatusEffect> SPEED = get("speed");
+	public static final Registry.Entry<StatusEffect> SLOWNESS = get("slowness");
+	public static final Registry.Entry<StatusEffect> HASTE = get("haste");
+	public static final Registry.Entry<StatusEffect> MINING_FATIGUE = get("mining_fatigue");
+	public static final Registry.Entry<StatusEffect> STRENGTH = get("strength");
+	public static final Registry.Entry<StatusEffect> INSTANT_HEALTH = get("instant_health");
+	public static final Registry.Entry<StatusEffect> INSTANT_DAMAGE = get("instant_damage");
+	public static final Registry.Entry<StatusEffect> JUMP_BOOST = get("jump_boost");
+	public static final Registry.Entry<StatusEffect> NAUSEA = get("nausea");
+	public static final Registry.Entry<StatusEffect> REGENERATION = get("regeneration");
+	public static final Registry.Entry<StatusEffect> RESISTANCE = get("resistance");
+	public static final Registry.Entry<StatusEffect> FIRE_RESISTANCE = get("fire_resistance");
+	public static final Registry.Entry<StatusEffect> WATER_BREATHING = get("water_breathing");
+	public static final Registry.Entry<StatusEffect> INVISIBILITY = get("invisibility");
+	public static final Registry.Entry<StatusEffect> BLINDNESS = get("blindness");
+	public static final Registry.Entry<StatusEffect> NIGHT_VISION = get("night_vision");
+	public static final Registry.Entry<StatusEffect> HUNGER = get("hunger");
+	public static final Registry.Entry<StatusEffect> WEAKNESS = get("weakness");
+	public static final Registry.Entry<StatusEffect> POISON = get("poison");
+	public static final Registry.Entry<StatusEffect> WITHER = get("wither");
+	public static final Registry.Entry<StatusEffect> HEALTH_BOOST = get("health_boost");
+	public static final Registry.Entry<StatusEffect> ABSORPTION = get("absorption");
+	public static final Registry.Entry<StatusEffect> SATURATION = get("saturation");
+	public static final Registry.Entry<StatusEffect> GLOWING = get("glowing");
+	public static final Registry.Entry<StatusEffect> LEVITATION = get("levitation");
+	public static final Registry.Entry<StatusEffect> LUCK = get("luck");
+	public static final Registry.Entry<StatusEffect> UNLUCK = get("unluck");
+	public static final Registry.Entry<StatusEffect> SLOW_FALLING = get("slow_falling");
+	public static final Registry.Entry<StatusEffect> CONDUIT_POWER = get("conduit_power");
+	public static final Registry.Entry<StatusEffect> DOLPHINS_GRACE = get("dolphins_grace");
+	public static final Registry.Entry<StatusEffect> BAD_OMEN = get("bad_omen");
+	public static final Registry.Entry<StatusEffect> HERO_OF_THE_VILLAGE = get("hero_of_the_village");
+
+	private static Registry.Entry<StatusEffect> get(String name) {
+		return StatusEffect.REGISTRY.get(Identity.of("minecraft", name));
+	}
+}

--- a/base/src/main/java/org/sandboxpowered/api/status/potion/BasePotion.java
+++ b/base/src/main/java/org/sandboxpowered/api/status/potion/BasePotion.java
@@ -1,0 +1,47 @@
+package org.sandboxpowered.api.status.potion;
+
+import org.sandboxpowered.api.status.StatusEffectInstance;
+import org.sandboxpowered.api.util.Mono;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class BasePotion implements Potion {
+	private Mono<String> name;
+	private List<StatusEffectInstance> effects;
+
+	public BasePotion(StatusEffectInstance... effects) {
+		this(Mono.empty(), effects);
+	}
+
+	public BasePotion(Mono<String> name, StatusEffectInstance... effects) {
+		this(name, Arrays.asList(effects));
+	}
+
+	public BasePotion(Mono<String> name, List<StatusEffectInstance> effects) {
+		this.name = name;
+		this.effects = effects;
+	}
+
+	@Override
+	public String getName(String itemName) {
+		return itemName + (this.name.isPresent() ? this.name : Potion.REGISTRY.getIdentity(this).getPath());
+	}
+
+	@Override
+	public List<StatusEffectInstance> getEffects() {
+		return new ArrayList<>(effects);
+	}
+
+	@Override
+	public boolean hasInstantEffect() {
+		if (!this.effects.isEmpty()) {
+			for (StatusEffectInstance effect : effects) {
+				if (effect.getEffect().isInstant()) return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/base/src/main/java/org/sandboxpowered/api/status/potion/Potion.java
+++ b/base/src/main/java/org/sandboxpowered/api/status/potion/Potion.java
@@ -1,0 +1,22 @@
+package org.sandboxpowered.api.status.potion;
+
+import org.sandboxpowered.api.content.Content;
+import org.sandboxpowered.api.registry.Registry;
+import org.sandboxpowered.api.status.StatusEffectInstance;
+
+import java.util.List;
+
+public interface Potion extends Content<Potion> {
+	Registry<Potion> REGISTRY = Registry.getRegistryFromType(Potion.class);
+
+	String getName(String itemName);
+
+	List<StatusEffectInstance> getEffects();
+
+	boolean hasInstantEffect();
+
+	@Override
+	default Class<Potion> getContentType() {
+		return Potion.class;
+	}
+}

--- a/base/src/main/java/org/sandboxpowered/api/status/potion/PotionSet.java
+++ b/base/src/main/java/org/sandboxpowered/api/status/potion/PotionSet.java
@@ -1,0 +1,119 @@
+package org.sandboxpowered.api.status.potion;
+
+import org.sandboxpowered.api.registry.Registry;
+import org.sandboxpowered.api.status.StatusEffectInstance;
+import org.sandboxpowered.api.util.Identity;
+import org.sandboxpowered.api.util.Mono;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public class PotionSet {
+	private Identity baseId;
+	private Potion base;
+	private PotionTypes types;
+	private Map<String, Potion> otherPotions = new HashMap<>();
+
+	public PotionSet(Identity baseId, Potion base) {
+		this(baseId, base, PotionTypes.NONE);
+	}
+
+	public PotionSet(Identity baseId, Potion base, PotionTypes types) {
+		this.baseId = baseId;
+		this.base = base;
+		this.types = types;
+		init();
+	}
+
+	public static PotionSet ofVanilla(Potion vanillaBase) {
+		Identity id = Potion.REGISTRY.getIdentity(vanillaBase);
+		return new PotionSet(vanillaBase,
+				Potion.REGISTRY.get(Identity.of("minecraft", "long_" + id.getPath())),
+				Potion.REGISTRY.get(Identity.of("minecraft", "long_" + id.getPath())));
+	}
+
+	private PotionSet(Potion base, Registry.Entry<Potion> longPot, Registry.Entry<Potion> strongPot) {
+		this.base = base;
+		Map<String, Potion> others = new HashMap<>();
+		if (longPot.isPresent()) others.put("long", longPot.get());
+		if (strongPot.isPresent()) others.put("strong", strongPot.get());
+		this.otherPotions = others;
+	}
+
+	public Potion getBasePotion() {
+		return base;
+	}
+
+	public Mono<Potion> getPotionFor(String modifier) {
+		return Mono.ofNullable(otherPotions.get(modifier));
+	}
+
+	public List<Potion> getAllPotions() {
+		List<Potion> all = new ArrayList<>();
+		all.add(base);
+		for (String key : otherPotions.keySet()) {
+			all.add(otherPotions.get(key));
+		}
+		return all;
+	}
+
+	private void init() {
+		//so that we don't need to hack potion brewing to bits
+		for (String key : types.getTypes().keySet()) {
+			Function<StatusEffectInstance, StatusEffectInstance> transformer = types.getTypes().get(key);
+			Identity newId = Identity.of(baseId.getNamespace(), key + "_" + baseId.getPath());
+			List<StatusEffectInstance> potEffects = new ArrayList<>();
+			for (StatusEffectInstance effect : base.getEffects()) {
+				potEffects.add(transformer.apply(effect));
+			}
+			Potion newPot = new BasePotion(Mono.of(base.getName("")), potEffects);
+			Potion.REGISTRY.register(newId, newPot);
+			otherPotions.put(key, newPot);
+		}
+	}
+
+	@FunctionalInterface
+	public interface PotionTypes {
+		Map<String, Function<StatusEffectInstance, StatusEffectInstance>> getTypes();
+
+		PotionTypes NONE = HashMap::new;
+		PotionTypes LONG = () -> {
+			Map<String, Function<StatusEffectInstance, StatusEffectInstance>> ret = new HashMap<>();
+			ret.put("long", (effect) -> {
+				if (effect.getEffect().isInstant()) throw new IllegalArgumentException("Cannot have a long form of an instant potion!");
+				//TODO: try to figure out a way this can round to the nearest hundred, maybe?
+				int newDur = (int)Math.ceil(effect.getDuration() * 2.667);
+				return StatusEffectInstance.of(effect.getEffect(), newDur, effect.getAmplifier());
+			});
+			return ret;
+		};
+		PotionTypes STRONG = () -> {
+			Map<String, Function<StatusEffectInstance, StatusEffectInstance>> ret = new HashMap<>();
+			ret.put("strong", (effect) -> {
+				//TODO: this isn't actually standard in vanilla, how should we deal with that?
+				int newDur = effect.getDuration() / 2;
+				return StatusEffectInstance.of(effect.getEffect(), newDur, effect.getAmplifier() + 1);
+			});
+			return ret;
+		};
+		PotionTypes LONG_AND_STRONG = () -> {
+			Map<String, Function<StatusEffectInstance, StatusEffectInstance>> ret = new HashMap<>();
+			ret.put("long", (effect) -> {
+				if (effect.getEffect().isInstant()) throw new IllegalArgumentException("Cannot have a long form of an instant potion!");
+				//TODO: try to figure out a way this can round to the nearest hundred, maybe?
+				int newDur = (int)Math.floor(effect.getDuration() * 2.667);
+				return StatusEffectInstance.of(effect.getEffect(), newDur, effect.getAmplifier());
+			});
+			ret.put("strong", (effect) -> {
+				//TODO: this isn't actually standard in vanilla, how should we deal with that?
+				int newDur = effect.getDuration() / 2;
+				return StatusEffectInstance.of(effect.getEffect(), newDur, effect.getAmplifier() + 1);
+			});
+			return ret;
+		};
+
+	}
+}

--- a/base/src/main/java/org/sandboxpowered/api/status/potion/PotionUtil.java
+++ b/base/src/main/java/org/sandboxpowered/api/status/potion/PotionUtil.java
@@ -1,0 +1,4 @@
+package org.sandboxpowered.api.status.potion;
+
+public class PotionUtil {
+}

--- a/base/src/main/java/org/sandboxpowered/api/status/potion/Potions.java
+++ b/base/src/main/java/org/sandboxpowered/api/status/potion/Potions.java
@@ -1,0 +1,39 @@
+package org.sandboxpowered.api.status.potion;
+
+import org.sandboxpowered.api.registry.Registry;
+import org.sandboxpowered.api.util.Identity;
+
+public class Potions {
+
+	public static final Registry.Entry<Potion> EMPTY = get("empty");
+	public static final Registry.Entry<Potion> WATER = get("water");
+	public static final Registry.Entry<Potion> MUNDANE = get("mundane");
+	public static final Registry.Entry<Potion> THICK = get("thick");
+	public static final Registry.Entry<Potion> AWKWARD = get("awkward");
+	//TODO: should we provide these as <POTION_NAME>_SET and have access to the individual objects too?
+	public static final PotionSet NIGHT_VISION = getSet("night_vision");
+	public static final PotionSet INVISIBILITY = getSet("invisibility");
+	public static final PotionSet LEAPING = getSet("leaping");
+	public static final PotionSet FIRE_RESISTANCE = getSet("fire_resistance");
+	public static final PotionSet SWIFTNESS = getSet("swiftness");
+	public static final PotionSet SLOWNESS = getSet("slowness");
+	public static final PotionSet TURTLE_MASTER = getSet("turtle_master");
+	public static final PotionSet WATER_BREATHING = getSet("water_breathing");
+	public static final PotionSet HEALING = getSet("healing");
+	public static final PotionSet HARMING = getSet("harming");
+	public static final PotionSet POISON = getSet("poison");
+	public static final PotionSet REGENERATION = getSet("regeneration");
+	public static final PotionSet STRENGTH = getSet("strength");
+	public static final PotionSet WEAKNESS = getSet("weakness");
+	public static final Registry.Entry<Potion> LUCK = get("luck"); //TODO: should be this be a Registry.Entry<Potion> or a PotionSet? There's no long/strong variants...
+	public static final PotionSet SLOW_FALLING = getSet("slow_falling");
+
+	private static Registry.Entry<Potion> get(String name) {
+		return Potion.REGISTRY.get(Identity.of("minecraft", name));
+	}
+
+	private static PotionSet getSet(String name) {
+		return PotionSet.ofVanilla(Potion.REGISTRY.get(Identity.of("minecraft", name)).get());
+	}
+
+}

--- a/base/src/main/java/org/sandboxpowered/api/util/Functions.java
+++ b/base/src/main/java/org/sandboxpowered/api/util/Functions.java
@@ -9,6 +9,10 @@ import org.sandboxpowered.api.item.ItemStack;
 import org.sandboxpowered.api.registry.Registry;
 import org.sandboxpowered.api.server.Server;
 import org.sandboxpowered.api.state.Property;
+import org.sandboxpowered.api.status.StatusEffect;
+import org.sandboxpowered.api.status.StatusEffectInstance;
+import org.sandboxpowered.api.status.StatusEffectType;
+import org.sandboxpowered.api.status.potion.Potion;
 import org.sandboxpowered.api.util.annotation.Internal;
 import org.sandboxpowered.api.util.math.Position;
 import org.sandboxpowered.api.util.math.Vec3i;
@@ -68,4 +72,8 @@ public interface Functions {
     FluidStack fluidStackFunction(Fluid fluid, int amount);
 
     FluidStack fluidStackFromTagFunction(ReadableCompoundTag tag);
+
+    StatusEffectInstance createStatusEffectInstance(StatusEffect effect, int duration, int amplifier);
+
+    StatusEffectType createStatusEffectType(String name);
 }


### PR DESCRIPTION
Carried over from #8. Not yet finished. Currently needs:
- [x] `StatusEffects` class for all vanilla status effects
- [x] `Potions` class for all vanilla potions
- [ ] Discuss: zero-index or one-index amplifiers?
- [x] Discuss: how to do strong/long `Potion` variants (hardcode register or add system for modifying based on item NBT)
- [ ] Potion util class
- [x] Potion item class?