### PR TITLE
Add system to provide a different SandboxAPI and Registrar to each addon

### DIFF
--- a/base/src/main/java/org/sandboxpowered/api/Sandbox.java
+++ b/base/src/main/java/org/sandboxpowered/api/Sandbox.java
@@ -1,0 +1,37 @@
+package org.sandboxpowered.api;
+
+import java.util.Map;
+
+import org.sandboxpowered.api.addon.Addon;
+import org.sandboxpowered.api.addon.AddonSpec;
+import org.sandboxpowered.api.registry.Registrar;
+
+public interface Sandbox {
+	Map<AddonSpec, Addon> getAllAddons();
+
+	SandboxAPI getAPIFor(AddonSpec spec);
+
+	Registrar getRegistrarFor(AddonSpec spec);
+
+	default void initializeAll() {
+		getAllAddons().forEach((spec, addon) -> {
+			SandboxAPI api = getAPIFor(spec);
+			try {
+				addon.init(api);
+			} catch (Exception e) {
+				throw new RuntimeException("Initialization for addon " + spec.getAddonId() + " failed: " + e);
+			}
+		});
+	}
+
+	default void registerAll() {
+		getAllAddons().forEach((spec, addon) -> {
+			Registrar registrar = getRegistrarFor(spec);
+			try {
+				addon.register(registrar);
+			} catch (Exception e) {
+				throw new RuntimeException("Registration for addon " + spec.getAddonId() + " failed: " + e);
+			}
+		});
+	}
+}

--- a/base/src/main/java/org/sandboxpowered/api/Sandbox.java
+++ b/base/src/main/java/org/sandboxpowered/api/Sandbox.java
@@ -1,37 +1,84 @@
 package org.sandboxpowered.api;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
+import com.github.zafarkhaja.semver.Parser;
+import com.github.zafarkhaja.semver.expr.Expression;
+import com.github.zafarkhaja.semver.expr.ExpressionParser;
 import org.sandboxpowered.api.addon.Addon;
 import org.sandboxpowered.api.addon.AddonSpec;
 import org.sandboxpowered.api.registry.Registrar;
+import org.sandboxpowered.api.util.Identity;
+import org.sandboxpowered.api.util.annotation.Internal;
 
+@Internal
 public interface Sandbox {
+	Parser<Expression> PARSER = ExpressionParser.newInstance();
+
+	static Sandbox getSandbox() {
+		throw new IllegalStateException("No Sandbox instance is defined! Please report this!");
+	}
+
+	Identity getPlatform();
+
+	Optional<AddonSpec> getAddon(String addonId);
+
 	Map<AddonSpec, Addon> getAllAddons();
 
 	SandboxAPI getAPIFor(AddonSpec spec);
 
 	Registrar getRegistrarFor(AddonSpec spec);
 
-	default void initializeAll() {
-		getAllAddons().forEach((spec, addon) -> {
-			SandboxAPI api = getAPIFor(spec);
-			try {
-				addon.init(api);
-			} catch (Exception e) {
-				throw new RuntimeException("Initialization for addon " + spec.getAddonId() + " failed: " + e);
+	default List<AddonSpec> getLoadOrder() {
+		Set<AddonSpec> visited = new HashSet<>();
+		List<AddonSpec> loadOrder = new ArrayList<>();
+		for (AddonSpec spec : getAllAddons().keySet()) {
+			handleDependencies(visited, loadOrder, spec);
+		}
+		return loadOrder;
+	}
+
+	//TODO: do we want to split this up between init and register?
+	default void launchAll() {
+		getLoadOrder().forEach(spec -> {
+			if (!spec.getPlatformSupport(getPlatform()).canRun()) {
+				throw new IllegalStateException(String.format("Addon %s cannot run on platform %s!", spec.getAddonId(), getPlatform().toString()));
+			}
+			Addon addon = getAllAddons().get(spec);
+			if (addon != null) {
+				SandboxAPI api = getAPIFor(spec);
+				Registrar registrar = getRegistrarFor(spec);
+				try {
+					addon.init(api);
+					addon.register(registrar);
+				} catch (Exception e) {
+					throw new RuntimeException(String.format("Initialization for addon %s failed: %s", spec.getAddonId(), e.getMessage()), e);
+				}
+			} else {
+				//TODO: log that an addon has no entrypoint?
 			}
 		});
 	}
 
-	default void registerAll() {
-		getAllAddons().forEach((spec, addon) -> {
-			Registrar registrar = getRegistrarFor(spec);
-			try {
-				addon.register(registrar);
-			} catch (Exception e) {
-				throw new RuntimeException("Registration for addon " + spec.getAddonId() + " failed: " + e);
-			}
-		});
+	//TODO: does this properly prevent circular dependencies while satisfying everything?
+	default void handleDependencies(Set<AddonSpec> visited, List<AddonSpec> order, AddonSpec spec) {
+		if (visited.contains(spec)) return;
+		visited.add(spec);
+		Map<String, String> dependencies = spec.getDependencies();
+		for (String dep : dependencies.keySet()) {
+			Optional<AddonSpec> optionalDep = getAddon(dep);
+			if (!optionalDep.isPresent()) throw new IllegalStateException(String.format("Addon %s depends on other addon %s that isn't loaded!", spec.getAddonId(), dep));
+			AddonSpec dependency = optionalDep.get();
+			String versionString = dependencies.get(dep);
+			Expression version = PARSER.parse(versionString);
+			if (!version.interpret(dependency.getVersion())) throw new IllegalStateException(String.format("Addon %s depends on %s version %s but found version %s instead!", spec.getAddonId(), dep, versionString, dependency.getVersion().toString()));
+			handleDependencies(visited, order, spec);
+		}
+		order.add(spec);
 	}
 }

--- a/base/src/main/java/org/sandboxpowered/api/Sandbox.java
+++ b/base/src/main/java/org/sandboxpowered/api/Sandbox.java
@@ -29,38 +29,38 @@ public interface Sandbox {
 
 	Identity getPlatform();
 
-	Optional<AddonSpec> getAddon(String addonId);
+	Optional<AddonInfo> getAddon(String addonId);
 
-	Map<AddonSpec, Addon> getAllAddons();
+	Map<AddonInfo, Addon> getAllAddons();
 
-	SandboxAPI getAPIFor(AddonInfo spec);
+	SandboxAPI getAPIFor(AddonInfo info);
 
-	Registrar getRegistrarFor(AddonInfo spec);
+	Registrar getRegistrarFor(AddonInfo info);
 
-	default List<AddonSpec> getLoadOrder() {
-		Set<AddonSpec> visited = new HashSet<>();
-		List<AddonSpec> loadOrder = new ArrayList<>();
-		for (AddonSpec spec : getAllAddons().keySet()) {
-			handleDependencies(visited, loadOrder, spec);
+	default List<AddonInfo> getLoadOrder() {
+		Set<AddonInfo> visited = new HashSet<>();
+		List<AddonInfo> loadOrder = new ArrayList<>();
+		for (AddonInfo info : getAllAddons().keySet()) {
+			handleDependencies(visited, loadOrder, info);
 		}
 		return loadOrder;
 	}
 
 	//TODO: do we want to split this up between init and register?
 	default void launchAll() {
-		getLoadOrder().forEach(spec -> {
-			if (!spec.getPlatformSupport(getPlatform()).canRun()) {
-				throw new IllegalStateException(String.format("Addon %s cannot run on platform %s!", spec.getAddonId(), getPlatform().toString()));
+		getLoadOrder().forEach(info -> {
+			if (!info.getPlatformSupport(getPlatform()).canRun()) {
+				throw new IllegalStateException(String.format("Addon %s cannot run on platform %s!", info.getAddonId(), getPlatform().toString()));
 			}
-			Addon addon = getAllAddons().get(spec);
+			Addon addon = getAllAddons().get(info);
 			if (addon != null) {
-				SandboxAPI api = getAPIFor(spec);
-				Registrar registrar = getRegistrarFor(spec);
+				SandboxAPI api = getAPIFor(info);
+				Registrar registrar = getRegistrarFor(info);
 				try {
 					addon.init(api);
 					addon.register(registrar);
 				} catch (Exception e) {
-					throw new RuntimeException(String.format("Initialization for addon %s failed: %s", spec.getAddonId(), e.getMessage()), e);
+					throw new RuntimeException(String.format("Initialization for addon %s failed: %s", info.getAddonId(), e.getMessage()), e);
 				}
 			} else {
 				//TODO: log that an addon has no entrypoint?
@@ -69,19 +69,19 @@ public interface Sandbox {
 	}
 
 	//TODO: does this properly prevent circular dependencies while satisfying everything?
-	default void handleDependencies(Set<AddonSpec> visited, List<AddonSpec> order, AddonSpec spec) {
-		if (visited.contains(spec)) return;
-		visited.add(spec);
-		Map<String, String> dependencies = spec.getDependencies();
+	default void handleDependencies(Set<AddonInfo> visited, List<AddonInfo> order, AddonInfo info) {
+		if (visited.contains(info)) return;
+		visited.add(info);
+		Map<String, String> dependencies = info.getDependencies();
 		for (String dep : dependencies.keySet()) {
-			Optional<AddonSpec> optionalDep = getAddon(dep);
-			if (!optionalDep.isPresent()) throw new IllegalStateException(String.format("Addon %s depends on other addon %s that isn't loaded!", spec.getAddonId(), dep));
-			AddonSpec dependency = optionalDep.get();
+			Optional<AddonInfo> optionalDep = getAddon(dep);
+			if (!optionalDep.isPresent()) throw new IllegalStateException(String.format("Addon %s depends on other addon %s that isn't loaded!", info.getAddonId(), dep));
+			AddonInfo dependency = optionalDep.get();
 			String versionString = dependencies.get(dep);
 			Expression version = PARSER.parse(versionString);
-			if (!version.interpret(dependency.getVersion())) throw new IllegalStateException(String.format("Addon %s depends on %s version %s but found version %s instead!", spec.getAddonId(), dep, versionString, dependency.getVersion().toString()));
-			handleDependencies(visited, order, spec);
+			if (!version.interpret(dependency.getVersion())) throw new IllegalStateException(String.format("Addon %s depends on %s version %s but found version %s instead!", info.getAddonId(), dep, versionString, dependency.getVersion().toString()));
+			handleDependencies(visited, order, info);
 		}
-		order.add(spec);
+		order.add(info);
 	}
 }

--- a/base/src/main/java/org/sandboxpowered/api/Sandbox.java
+++ b/base/src/main/java/org/sandboxpowered/api/Sandbox.java
@@ -17,8 +17,6 @@ import org.sandboxpowered.api.registry.Registrar;
 import org.sandboxpowered.api.util.Identity;
 import org.sandboxpowered.api.util.annotation.Internal;
 
-import java.util.Map;
-
 @Internal
 public interface Sandbox {
 	Parser<Expression> PARSER = ExpressionParser.newInstance();
@@ -46,24 +44,32 @@ public interface Sandbox {
 		return loadOrder;
 	}
 
-	//TODO: do we want to split this up between init and register?
-	default void launchAll() {
+	default void initAll() {
 		getLoadOrder().forEach(info -> {
 			if (!info.getPlatformSupport(getPlatform()).canRun()) {
-				throw new IllegalStateException(String.format("Addon %s cannot run on platform %s!", info.getAddonId(), getPlatform().toString()));
+				throw new IllegalStateException(String.format("Addon %s cannot run on platform %s!", info.getId(), getPlatform().toString()));
 			}
 			Addon addon = getAllAddons().get(info);
-			if (addon != null) {
-				SandboxAPI api = getAPIFor(info);
-				Registrar registrar = getRegistrarFor(info);
-				try {
-					addon.init(api);
-					addon.register(registrar);
-				} catch (Exception e) {
-					throw new RuntimeException(String.format("Initialization for addon %s failed: %s", info.getAddonId(), e.getMessage()), e);
-				}
-			} else {
-				//TODO: log that an addon has no entrypoint?
+			SandboxAPI api = getAPIFor(info);
+			try {
+				addon.init(api);
+			} catch (Exception e) {
+				throw new RuntimeException(String.format("Initialization for addon %s failed: %s", info.getId(), e.getMessage()), e);
+			}
+		});
+	}
+
+	default void registerAll() {
+		getLoadOrder().forEach(info -> {
+			if (!info.getPlatformSupport(getPlatform()).canRun()) {
+				throw new IllegalStateException(String.format("Addon %s cannot run on platform %s!", info.getId(), getPlatform().toString()));
+			}
+			Addon addon = getAllAddons().get(info);
+			Registrar registrar = getRegistrarFor(info);
+			try {
+				addon.register(registrar);
+			} catch (Exception e) {
+				throw new RuntimeException(String.format("Initialization for addon %s failed: %s", info.getId(), e.getMessage()), e);
 			}
 		});
 	}
@@ -75,11 +81,11 @@ public interface Sandbox {
 		Map<String, String> dependencies = info.getDependencies();
 		for (String dep : dependencies.keySet()) {
 			Optional<AddonInfo> optionalDep = getAddon(dep);
-			if (!optionalDep.isPresent()) throw new IllegalStateException(String.format("Addon %s depends on other addon %s that isn't loaded!", info.getAddonId(), dep));
+			if (!optionalDep.isPresent()) throw new IllegalStateException(String.format("Addon %s depends on other addon %s that isn't loaded!", info.getId(), dep));
 			AddonInfo dependency = optionalDep.get();
 			String versionString = dependencies.get(dep);
 			Expression version = PARSER.parse(versionString);
-			if (!version.interpret(dependency.getVersion())) throw new IllegalStateException(String.format("Addon %s depends on %s version %s but found version %s instead!", info.getAddonId(), dep, versionString, dependency.getVersion().toString()));
+			if (!version.interpret(dependency.getVersion())) throw new IllegalStateException(String.format("Addon %s depends on %s version %s but found version %s instead!", info.getId(), dep, versionString, dependency.getVersion().toString()));
 			handleDependencies(visited, order, info);
 		}
 		order.add(info);

--- a/base/src/main/java/org/sandboxpowered/api/SandboxAPI.java
+++ b/base/src/main/java/org/sandboxpowered/api/SandboxAPI.java
@@ -1,9 +1,12 @@
 package org.sandboxpowered.api;
 
+import org.sandboxpowered.api.addon.AddonSpec;
 import org.sandboxpowered.api.util.Log;
 import org.sandboxpowered.api.util.Side;
 
 public interface SandboxAPI {
+    AddonSpec getSourceAddon();
+
     Side getSide();
 
     default void execute(Side side, Runnable runnable) {

--- a/base/src/main/java/org/sandboxpowered/api/addon/AddonInfo.java
+++ b/base/src/main/java/org/sandboxpowered/api/addon/AddonInfo.java
@@ -13,7 +13,7 @@ public interface AddonInfo {
     /**
      * @return The ID of this addon.
      */
-    String getAddonId();
+    String getId();
 
     /**
      * @return The version of this addon as SemVer.

--- a/base/src/main/java/org/sandboxpowered/api/addon/AddonInfo.java
+++ b/base/src/main/java/org/sandboxpowered/api/addon/AddonInfo.java
@@ -1,35 +1,96 @@
 package org.sandboxpowered.api.addon;
 
+import com.electronwill.nightconfig.core.Config;
 import com.github.zafarkhaja.semver.Version;
 import org.sandboxpowered.api.util.Identity;
 
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 
 public interface AddonInfo {
-    String getId();
+    /**
+     * @return The ID of this addon.
+     */
+    String getAddonId();
 
+    /**
+     * @return The version of this addon as SemVer.
+     */
     Version getVersion();
 
+    /**
+     * @return The display name of this addon.
+     */
     String getTitle();
 
+    /**
+     * @return The description of this addon.
+     */
     String getDescription();
 
-    String getMainClass();
-
+    /**
+     * @return A list of the authors of this addon.
+     */
     List<String> getAuthors();
 
+    /**
+     * @return The URL for the home page of this addon.
+     */
     String getUrl();
 
+    /**
+     * @return The loading side of this addon.
+     */
     LoadingSide getSide();
 
-    URL getPath();
+    /**
+     * @return A map of the names and versions of all addons this addon has a dependency on.
+     */
+    Map<String, String> getDependencies();
 
+    /**
+     * @return Any custom properties this addon defines.
+     */
+    Config getCustomProperties();
+
+    /**
+     * @return A map of platform identities to definite support states.
+     */
+    Map<String, Boolean> getPlatforms();
+
+    /**
+     * @param platform The platform to test for.
+     * @return The level of support this addon has for the given platform.
+     */
     PlatformSupport getPlatformSupport(Identity platform);
 
+    /**
+     * @return The full qualified name of the entrypoint class for this addon.
+     */
+    String getMainClass();
+
+    /**
+     * @return The path this addon is at relative to the game instance.
+     */
+    URL getPath();
+
     enum PlatformSupport {
+        /**
+         * This platform is definitely supported.
+         */
         YES,
+        /**
+         * It is not known whether this platform is supported.
+         */
         MAYBE,
-        NO
+        /**
+         * This platform is definitely not supported.
+         */
+        NO;
+
+        public boolean canRun() {
+            return this != NO;
+        }
     }
 }

--- a/base/src/main/java/org/sandboxpowered/api/addon/AddonInfo.java
+++ b/base/src/main/java/org/sandboxpowered/api/addon/AddonInfo.java
@@ -3,6 +3,7 @@ package org.sandboxpowered.api.addon;
 import com.electronwill.nightconfig.core.Config;
 import com.github.zafarkhaja.semver.Version;
 import org.sandboxpowered.api.util.Identity;
+import org.sandboxpowered.api.util.annotation.Internal;
 
 import java.net.URL;
 import java.util.List;
@@ -68,11 +69,13 @@ public interface AddonInfo {
     /**
      * @return The full qualified name of the entrypoint class for this addon.
      */
+    @Internal
     String getMainClass();
 
     /**
      * @return The path this addon is at relative to the game instance.
      */
+    @Internal
     URL getPath();
 
     enum PlatformSupport {

--- a/base/src/main/java/org/sandboxpowered/api/addon/AddonSpec.java
+++ b/base/src/main/java/org/sandboxpowered/api/addon/AddonSpec.java
@@ -1,6 +1,7 @@
 package org.sandboxpowered.api.addon;
 
 import com.electronwill.nightconfig.core.Config;
+import com.electronwill.nightconfig.core.ConfigSpec;
 import com.github.zafarkhaja.semver.Version;
 import org.sandboxpowered.api.util.Identity;
 import org.sandboxpowered.api.util.annotation.Internal;
@@ -15,22 +16,27 @@ import java.util.regex.Pattern;
 
 @Internal
 public class AddonSpec implements AddonInfo {
+    private static final ConfigSpec CONFIG_SPEC = new ConfigSpec();
     private static final Pattern MODID_PATTERN = Pattern.compile("[a-z0-9-_]{4,15}");
     private static final Predicate<String> MODID_PREDICATE = MODID_PATTERN.asPredicate();
+
+    //metadata
     private final String addonId;
     private final Version version;
     private final String title;
     private final String description;
-    private final String mainClass;
     private final List<String> authors;
     private final String url;
+    private final Map<String, String> dependencies;
+    private final Config customProperties;
     private final LoadingSide side;
-    private final URL path;
     private final Map<String, Boolean> platforms;
 
-    private AddonSpec(String addonId, Version version, @Nullable String title, String description, String mainClass, List<String> authors, String url, LoadingSide side, URL path, Map<String, Boolean> platforms) {
-        this.path = path;
-        this.platforms = platforms;
+    //internal info
+    private final String mainClass;
+    private final URL path;
+
+    private AddonSpec(String addonId, Version version, @Nullable String title, String description, List<String> authors, String url, Map<String, String> dependencies, Config customProperties, LoadingSide side, Map<String, Boolean> platforms, String mainClass, URL path) {
         if (!MODID_PREDICATE.test(addonId))
             throw new IllegalArgumentException(String.format("addon ID '%s' does not match regex requirement '%s'", addonId, MODID_PATTERN.pattern()));
         this.addonId = addonId;
@@ -39,30 +45,37 @@ public class AddonSpec implements AddonInfo {
             title = addonId;
         this.title = title;
         this.description = description;
-        this.mainClass = mainClass;
         if (authors.isEmpty())
             throw new IllegalArgumentException("authors does not meet minimum list requirement of 1");
         this.authors = authors;
         this.url = url;
+        this.dependencies = dependencies;
+        this.customProperties = customProperties;
         this.side = side;
+        this.platforms = platforms;
+        this.mainClass = mainClass;
+        this.path = path;
     }
 
     public static AddonSpec from(Config config, URL path) {
+        CONFIG_SPEC.correct(config);
         String id = config.get("id");
+        if (id.equals("")) throw new IllegalArgumentException(String.format("Addon ID for addon at path %s is not defined!", path.toString()));
         Version version = Version.valueOf(config.get("version"));
-        String title = config.contains("title") ? config.get("title") : id;
-        String description = config.contains("description") ? config.get("description") : "";
+        String title = config.get("title");
+        String description = config.get("description");
         String mainClass = config.get("entrypoint");
         List<String> authors = config.get("authors");
-        String url = config.contains("url") ? config.get("url") : "";
-        String sideS = config.contains("side") ? config.get("side") : "COMMON";
-        LoadingSide side = sideS.equalsIgnoreCase("CLIENT") ? LoadingSide.CLIENT : sideS.equalsIgnoreCase("SERVER") ? LoadingSide.SERVER : LoadingSide.COMMON;
-        Map<String, Boolean> platforms = config.contains("platforms") ? config.get("platforms") : Collections.emptyMap();
-        return new AddonSpec(id, version, title, description, mainClass, authors, url, side, path, platforms);
+        String url = config.get("url");
+        Map<String, String> dependencies = config.get("dependencies");
+        Config customProperties = config.get("custom");
+        LoadingSide side = config.getEnum("side", LoadingSide.class);
+        Map<String, Boolean> platforms = config.get("platforms");
+        return new AddonSpec(id, version, title, description, authors, url, dependencies, customProperties, side, platforms, mainClass, path);
     }
 
     @Override
-    public String getId() {
+    public String getAddonId() {
         return addonId;
     }
 
@@ -82,11 +95,6 @@ public class AddonSpec implements AddonInfo {
     }
 
     @Override
-    public String getMainClass() {
-        return mainClass;
-    }
-
-    @Override
     public List<String> getAuthors() {
         return authors;
     }
@@ -102,16 +110,46 @@ public class AddonSpec implements AddonInfo {
     }
 
     @Override
-    public URL getPath() {
-        return path;
+    public Map<String, String> getDependencies() {
+        return dependencies;
     }
 
+    @Override
+    public Config getCustomProperties() {
+        return customProperties;
+    }
+
+    @Override
     public Map<String, Boolean> getPlatforms() {
         return platforms;
     }
 
     @Override
-    public PlatformSupport getPlatformSupport(Identity platform) {
-        return platforms.containsKey(platform.toString()) ? platforms.get(platform.toString()) ? PlatformSupport.YES : PlatformSupport.NO : PlatformSupport.MAYBE;
+    public AddonSpec.PlatformSupport getPlatformSupport(Identity platform) {
+        return platforms.containsKey(platform.toString()) ? platforms.get(platform.toString()) ? AddonSpec.PlatformSupport.YES : AddonSpec.PlatformSupport.NO : AddonSpec.PlatformSupport.MAYBE;
+    }
+
+    @Override
+    public String getMainClass() {
+        return mainClass;
+    }
+
+    @Override
+    public URL getPath() {
+        return path;
+    }
+
+    static {
+        CONFIG_SPEC.define("id", "");
+        CONFIG_SPEC.define("version", "1.0.0");
+        CONFIG_SPEC.define("title", "");
+        CONFIG_SPEC.define("description", "");
+        CONFIG_SPEC.define("entrypoint", "");
+        CONFIG_SPEC.define("authors", Collections.emptyList());
+        CONFIG_SPEC.define("url", "");
+        CONFIG_SPEC.define("dependencies", Collections.emptyMap());
+        CONFIG_SPEC.define("custom", Config.inMemoryUniversal());
+        CONFIG_SPEC.defineOfClass("side", LoadingSide.COMMON, LoadingSide.class);
+        CONFIG_SPEC.define("platforms", Collections.emptyMap());
     }
 }

--- a/base/src/main/java/org/sandboxpowered/api/addon/AddonSpec.java
+++ b/base/src/main/java/org/sandboxpowered/api/addon/AddonSpec.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
 public class AddonSpec {
     private static final Pattern MODID_PATTERN = Pattern.compile("[a-z0-9-_]{4,15}");
     private static final Predicate<String> MODID_PREDICATE = MODID_PATTERN.asPredicate();
-    private final String modid;
+    private final String addonId;
     private final Version version;
     private final String title;
     private final String description;
@@ -28,15 +28,15 @@ public class AddonSpec {
     private final URL path;
     private final Map<String, Boolean> platforms;
 
-    private AddonSpec(String modid, Version version, @Nullable String title, String description, String mainClass, List<String> authors, String url, LoadingSide side, URL path, Map<String, Boolean> platforms) {
+    private AddonSpec(String addonId, Version version, @Nullable String title, String description, String mainClass, List<String> authors, String url, LoadingSide side, URL path, Map<String, Boolean> platforms) {
         this.path = path;
         this.platforms = platforms;
-        if (!MODID_PREDICATE.test(modid))
-            throw new IllegalArgumentException(String.format("modid '%s' does not match regex requirement '%s'", modid, MODID_PATTERN.pattern()));
-        this.modid = modid;
+        if (!MODID_PREDICATE.test(addonId))
+            throw new IllegalArgumentException(String.format("addon ID '%s' does not match regex requirement '%s'", addonId, MODID_PATTERN.pattern()));
+        this.addonId = addonId;
         this.version = version;
         if (title == null || title.isEmpty())
-            title = modid;
+            title = addonId;
         this.title = title;
         this.description = description;
         this.mainClass = mainClass;
@@ -48,7 +48,7 @@ public class AddonSpec {
     }
 
     public static AddonSpec from(Config config, URL path) {
-        String modid = config.get("modid");
+        String modid = config.get("id");
         Version version = Version.valueOf(config.get("version"));
         String title = config.contains("title") ? config.get("title") : modid;
         String description = config.contains("description") ? config.get("description") : "";
@@ -61,8 +61,8 @@ public class AddonSpec {
         return new AddonSpec(modid, version, title, description, mainClass, authors, url, side, path, platforms);
     }
 
-    public String getModid() {
-        return modid;
+    public String getAddonId() {
+        return addonId;
     }
 
     public Version getVersion() {

--- a/base/src/main/java/org/sandboxpowered/api/addon/AddonSpec.java
+++ b/base/src/main/java/org/sandboxpowered/api/addon/AddonSpec.java
@@ -21,7 +21,7 @@ public class AddonSpec implements AddonInfo {
     private static final Predicate<String> MODID_PREDICATE = MODID_PATTERN.asPredicate();
 
     //metadata
-    private final String addonId;
+    private final String id;
     private final Version version;
     private final String title;
     private final String description;
@@ -36,17 +36,17 @@ public class AddonSpec implements AddonInfo {
     private final String mainClass;
     private final URL path;
 
-    private AddonSpec(String addonId, Version version, @Nullable String title, String description, List<String> authors, String url, Map<String, String> dependencies, Config customProperties, LoadingSide side, Map<String, Boolean> platforms, String mainClass, URL path) {
-        if (!MODID_PREDICATE.test(addonId))
-            throw new IllegalArgumentException(String.format("addon ID '%s' does not match regex requirement '%s'", addonId, MODID_PATTERN.pattern()));
-        this.addonId = addonId;
+    private AddonSpec(String id, Version version, @Nullable String title, String description, List<String> authors, String url, Map<String, String> dependencies, Config customProperties, LoadingSide side, Map<String, Boolean> platforms, String mainClass, URL path) {
+        if (!MODID_PREDICATE.test(id))
+            throw new IllegalArgumentException(String.format("Addon ID '%s' does not match regex requirement '%s'", id, MODID_PATTERN.pattern()));
+        this.id = id;
         this.version = version;
         if (title == null || title.isEmpty())
-            title = addonId;
+            title = id;
         this.title = title;
         this.description = description;
         if (authors.isEmpty())
-            throw new IllegalArgumentException("authors does not meet minimum list requirement of 1");
+            throw new IllegalArgumentException(String.format("Addon %s does not define any authors!", id));
         this.authors = authors;
         this.url = url;
         this.dependencies = dependencies;
@@ -60,11 +60,14 @@ public class AddonSpec implements AddonInfo {
     public static AddonSpec from(Config config, URL path) {
         CONFIG_SPEC.correct(config);
         String id = config.get("id");
-        if (id.equals("")) throw new IllegalArgumentException(String.format("Addon ID for addon at path %s is not defined!", path.toString()));
-        Version version = Version.valueOf(config.get("version"));
+        if (id.equals("")) throw new IllegalArgumentException(String.format("Addon at path %s does not define an ID!", path.toString()));
+        String verString = config.get("version");
+        if (verString.equals("")) throw new IllegalArgumentException(String.format("Addon %s does not define a version!", id));
+        Version version = Version.valueOf(verString);
         String title = config.get("title");
         String description = config.get("description");
         String mainClass = config.get("entrypoint");
+        if (mainClass.equals("")) throw new IllegalArgumentException(String.format("Addon %s does not define an entrypoint!", id));
         List<String> authors = config.get("authors");
         String url = config.get("url");
         Map<String, String> dependencies = config.get("dependencies");
@@ -75,8 +78,8 @@ public class AddonSpec implements AddonInfo {
     }
 
     @Override
-    public String getAddonId() {
-        return addonId;
+    public String getId() {
+        return id;
     }
 
     @Override
@@ -141,7 +144,7 @@ public class AddonSpec implements AddonInfo {
 
     static {
         CONFIG_SPEC.define("id", "");
-        CONFIG_SPEC.define("version", "1.0.0");
+        CONFIG_SPEC.define("version", "");
         CONFIG_SPEC.define("title", "");
         CONFIG_SPEC.define("description", "");
         CONFIG_SPEC.define("entrypoint", "");

--- a/base/src/main/java/org/sandboxpowered/api/addon/LoadingSide.java
+++ b/base/src/main/java/org/sandboxpowered/api/addon/LoadingSide.java
@@ -1,8 +1,20 @@
 package org.sandboxpowered.api.addon;
 
+/**
+ * Defines the side to load an addon on. Refers to physical client/server, not logical client/server.
+ */
 public enum LoadingSide {
+    /**
+     * The loading side for a physical dedicated server.
+     */
     SERVER,
+    /**
+     * The loading side for a physical client.
+     */
     CLIENT,
+    /**
+     * Both server and client.
+     */
     COMMON;
 
     public boolean isClient() {

--- a/base/src/main/java/org/sandboxpowered/api/registry/Registrar.java
+++ b/base/src/main/java/org/sandboxpowered/api/registry/Registrar.java
@@ -14,6 +14,6 @@ public interface Registrar {
     <T extends Content<T>> Registry.Entry<T> register(Identity identity, T content);
 
     default <T extends Content<T>> Registry.Entry<T> register(String name, T content) {
-        return register(Identity.of(getSourceAddon().getAddonId(), name), content);
+        return register(Identity.of(getSourceAddon().getId(), name), content);
     }
 }

--- a/base/src/main/java/org/sandboxpowered/api/registry/Registrar.java
+++ b/base/src/main/java/org/sandboxpowered/api/registry/Registrar.java
@@ -14,6 +14,6 @@ public interface Registrar {
     <T extends Content<T>> Registry.Entry<T> register(Identity identity, T content);
 
     default <T extends Content<T>> Registry.Entry<T> register(String name, T content) {
-        return register(Identity.of(getSourceAddon().getId(), name), content);
+        return register(Identity.of(getSourceAddon().getAddonId(), name), content);
     }
 }

--- a/base/src/main/java/org/sandboxpowered/api/registry/Registrar.java
+++ b/base/src/main/java/org/sandboxpowered/api/registry/Registrar.java
@@ -1,12 +1,19 @@
 package org.sandboxpowered.api.registry;
 
+import org.sandboxpowered.api.addon.AddonSpec;
 import org.sandboxpowered.api.content.Content;
 import org.sandboxpowered.api.util.Identity;
 
 public interface Registrar {
+    AddonSpec getSourceAddon();
+
     <T extends Content<T>> Registry.Entry<T> getEntry(Identity identity, Class<T> tClass);
 
     <T extends Content<T>> Registry.Entry<T> getEntry(Identity identity, Registry<T> registry);
 
     <T extends Content<T>> Registry.Entry<T> register(Identity identity, T content);
+
+    default <T extends Content<T>> Registry.Entry<T> register(String name, T content) {
+        return register(Identity.of(getSourceAddon().getAddonId(), name), content);
+    }
 }

--- a/base/src/main/java/org/sandboxpowered/api/util/Functions.java
+++ b/base/src/main/java/org/sandboxpowered/api/util/Functions.java
@@ -28,7 +28,7 @@ public interface Functions {
 
     @Nonnull
     static Functions getInstance() {
-        throw new RuntimeException("No functions defined, this is a bug.");
+        throw new IllegalStateException("No functions defined, this is a bug.");
     }
 
     Identity createIdentityFromString(String identity);


### PR DESCRIPTION
- Adds `AddonSpec getSourceAddon()` method to `SandboxAPI` and `Registrar`
- Adds `register(String name, T content)` method to `Registrar` which auto-populates addon ID from spec
- Adds `Sandbox` interface which defines a method to obtain a map of all addons to their entrypoints, methods to obtain `SandboxAPI` and `Registrar` instances for a given addon, and defaulted methods to run `initialize` and `register` for all addons
- Renames `modid` in `AddonSpec` to `addonId` in code, and `id` in config.