### PR TITLE
Add dynamic ingredients

### DIFF
--- a/modules/base/src/main/java/org/sandboxpowered/api/recipe/Ingredient.java
+++ b/modules/base/src/main/java/org/sandboxpowered/api/recipe/Ingredient.java
@@ -5,12 +5,16 @@ import com.google.gson.JsonElement;
 import java.util.function.Predicate;
 
 public interface Ingredient<S> extends Predicate<S> {
-    static <T> Ingredient<T> from(T t) {
+    static <T> Ingredient<T> of(T t) {
         return null;
     }
 
     @SafeVarargs
-    static <T> Ingredient<T> from(T... ts) {
+    static <T> Ingredient<T> of(T... ts) {
+        return null;
+    }
+
+    static <T> Ingredient<T> fromJson(Class<T> type, JsonElement element) {
         return null;
     }
 

--- a/modules/base/src/main/java/org/sandboxpowered/api/recipe/Ingredient.java
+++ b/modules/base/src/main/java/org/sandboxpowered/api/recipe/Ingredient.java
@@ -5,9 +5,22 @@ import com.google.gson.JsonElement;
 import java.util.function.Predicate;
 
 public interface Ingredient<S> extends Predicate<S> {
+    static <T> Ingredient<T> from(T t) {
+        return null;
+    }
+
+    @SafeVarargs
+    static <T> Ingredient<T> from(T... ts) {
+        return null;
+    }
+
     S[] getMatching();
 
     boolean isEmpty();
 
     JsonElement toJson();
+
+    interface Deserializer<T> {
+        Ingredient<T> fromJson(JsonElement element);
+    }
 }


### PR DESCRIPTION
Creates an ingredient interface which is generic for Item, Block or Fluid, needs input on what mods require when it comes to custom ingredients.

This hopes to resolve #33.